### PR TITLE
fixed debug type for win32 + allow user to chose debug type via settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ for Zig development:
 It also displays code lenses above tests to run or debug single test, and code
 lens at the first line of the file to run all tests.
 
-It [depends](package.json#L8) on several extensions:
+It depends on several extensions:
 
 - [Zig Language](https://marketplace.visualstudio.com/items?itemName=ziglang.vscode-zig)
 for location of Zig binary

--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ for Zig development:
 It also displays code lenses above tests to run or debug single test, and code
 lens at the first line of the file to run all tests.
 
-It
-[depends](https://github.com/ianic/zig-language-extras/blob/de59f5422a73d976fa47961fb2cb0974037687b4/package.json#L8)
-on three other extensions.
-[Zig Language](https://marketplace.visualstudio.com/items?itemName=ziglang.vscode-zig)
-for location of Zig binary. [Native
-Debug](https://marketplace.visualstudio.com/items?itemName=webfreak.debug) for
-launching debugger on Linux and
-[CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)
-for debugging on MacOS.
+It [depends](package.json#L8) on several extensions:
+
+- [Zig Language](https://marketplace.visualstudio.com/items?itemName=ziglang.vscode-zig)
+for location of Zig binary
+- [Native Debug](https://marketplace.visualstudio.com/items?itemName=webfreak.debug) for
+debugging on Linux
+- [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)
+for debugging on MacOS
+- [C/C++](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb) for debugging on Windows
 
 
 The main reason I decided to make this is to create fine vscode problems
@@ -74,6 +74,13 @@ which is expected to be root of your workspace. If the current file is in some
 other folder then the name of the current file is used as name of the binary
 except if that file is named main.zig then folder name of that file is used as
 expected binary name.
+
+You can modify debugger via settings: `"zig-language-extras.debugType": "type"`. Type refers to the specific `"type"` field that you would use in the launch.json file.
+
+The default debugger types for each platform are as follows:
+- "lldb" for darwin platform
+- "cppvsdbg" for win32 platform
+- "gdb" for other platforms
 
 ## Keybinding tip
 

--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
   "name": "zig-language-extras",
   "displayName": "Zig Language Extras",
   "description": "Commands for testing and debugging Zig Language files/projects",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "repository": "https://github.com/ianic/zig-language-extras.git",
   "publisher": "ianic",
   "extensionDependencies": [
     "ziglang.vscode-zig",
     "vadimcn.vscode-lldb",
-    "webfreak.debug"
+    "webfreak.debug",
+    "ms-vscode.cpptools"
   ],
   "engines": {
     "vscode": "^1.79.0"
@@ -31,6 +32,10 @@
           "type": "string",
           "default": "./zig-out/debug/test",
           "description": "File path to emit binary when debugging Zig test."
+        },
+        "zig-language-extras.debugType": {
+          "type": "string",
+          "description": "Type to use for debugging, similar to what you would provide in the launch.json file. Examples: 'gdb', 'lldb' (default for darwin platform), 'cppvsdbg' (default for win32 platform)."
         }
       }
     },


### PR DESCRIPTION
Hello again!

I had a problem with zig that forced it to recompile everything in my project from scratch in wsl, so I switched to windows. And I've got another one problem: I couldn't debug my app with gdb. The only solution I found was to use MSVC debugger (using "type"="cppvsdbg").

This pull request enables the ability for a user to modify the debug type and sets a rational default debug type value for windows platform.