### PR TITLE
Zig path fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zig-language-extras",
   "displayName": "Zig Language Extras",
   "description": "Commands for testing and debugging Zig Language files/projects",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "repository": "https://github.com/ianic/zig-language-extras.git",
   "publisher": "ianic",
   "extensionDependencies": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -210,7 +210,7 @@ function runZig(args: string[], cwd: string, successCallback?: () => void) {
 
 	// get zig binary from zig extension configuration
 	const zigConfig = vscode.workspace.getConfiguration('zig');
-	const zigPath = zigConfig.get<string>("zigPath") || "zig";
+	const zigPath = zigConfig.get<string>("path") || "zig";
 
 	if (args[0] === "test") {
 		// append additional test arguments if set in configuration

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -221,7 +221,7 @@ function runZig(args: string[], cwd: string, successCallback?: () => void) {
 	}
 
 	// show running command in output (so can be analyzed or copied to terminal)
-	output.appendLine("Running: zig " + quote(args).join(' '));
+	output.appendLine(`Running: ${zigPath} ` + quote(args).join(' '));
 
 	cp.execFile(zigPath, args, { cwd }, (err, stdout, stderr) => {
 		if (stderr.trim().length > 0) {


### PR DESCRIPTION
Hello!

They renamed zigPath to path in [this](https://github.com/ziglang/vscode-zig/commit/1c036d761f4acdd797d77c91a9307e1806661701) commit (at 101 line), so I updated your extension according to that.

I also added more verbosity to "Running..." message. It now displays full path to executable instead of just "zig".